### PR TITLE
fix: use `ec` library instead of standard library

### DIFF
--- a/Nargo.toml
+++ b/Nargo.toml
@@ -5,3 +5,4 @@ authors = [""]
 compiler_version = ">=0.37.0"
 
 [dependencies]
+ec = { tag = "v0.1.2", git = "https://github.com/noir-lang/ec" }

--- a/src/lib.nr
+++ b/src/lib.nr
@@ -2,7 +2,7 @@ mod scalar_field;
 mod test;
 mod bjj;
 
-use crate::scalar_field::ScalarField;
+pub use crate::scalar_field::ScalarField;
 
 pub struct Curve<Params> {
     x: Field,

--- a/src/scalar_field.nr
+++ b/src/scalar_field.nr
@@ -10,9 +10,9 @@
 ///
 /// N.B. ScalarField bit values are not constrained to be smaller than the TE curve group order.
 /// ScalarField is used when performing scalar multiplications, where all operations wrap modulo the curve order
-struct ScalarField<let N: u32> {
-    base4_slices: [u8; N],
-    skew: bool,
+pub struct ScalarField<let N: u32> {
+    pub(crate) base4_slices: [u8; N],
+    pub(crate) skew: bool,
 }
 
 unconstrained fn get_wnaf_slices<let N: u32>(x: Field) -> ([u8; N], bool) {
@@ -148,7 +148,7 @@ impl<let N: u32> std::convert::Into<Field> for ScalarField<N> {
 
 impl<let N: u32> ScalarField<N> {
 
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self { base4_slices: [0; N], skew: false }
     }
     fn get(self, idx: u64) -> u8 {

--- a/src/test.nr
+++ b/src/test.nr
@@ -1,8 +1,8 @@
 use crate::bjj::BabyJubJubParams;
 use crate::Curve;
 use crate::scalar_field::ScalarField;
-use std::ec::consts::te::baby_jubjub;
-use std::ec::tecurve::affine::Point as TEPoint;
+
+use ec::{consts::te::baby_jubjub, tecurve::affine::Point as TEPoint};
 
 type BabyJubJub = Curve<BabyJubJubParams>;
 


### PR DESCRIPTION
# Description

## Problem\*

Resolves #12 

## Summary\*

This replaces the usage of the stdlib with https://github.com/noir-lang/ec

## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
