### PR TITLE
fix: nightly version test fails

### DIFF
--- a/Nargo.toml
+++ b/Nargo.toml
@@ -5,3 +5,4 @@ authors = [""]
 compiler_version = ">=0.37.0"
 
 [dependencies]
+ec = { tag = "v0.1.2", git = "https://github.com/noir-lang/ec" }

--- a/src/test.nr
+++ b/src/test.nr
@@ -1,8 +1,8 @@
 use crate::bjj::BabyJubJubParams;
 use crate::Curve;
 use crate::scalar_field::ScalarField;
-use std::ec::consts::te::baby_jubjub;
-use std::ec::tecurve::affine::Point as TEPoint;
+use dep::ec::consts::te::baby_jubjub;
+use ec::tecurve::affine::Point as TEPoint;
 
 type BabyJubJub = Curve<BabyJubJubParams>;
 


### PR DESCRIPTION
# Description
switched the lib to use noir_ec instead of stdlib
## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
