### PR TITLE
chore: explicitly import `CurveTrait` for `sub` trait method and remove some default implementations

### DIFF
--- a/src/lib.nr
+++ b/src/lib.nr
@@ -3,6 +3,7 @@ mod test;
 mod bjj;
 
 pub use crate::scalar_field::ScalarField;
+use std::ops::{Add, Neg, Sub};
 
 pub struct Curve<Params> {
     x: Field,
@@ -23,23 +24,10 @@ trait TECurveParameterTrait {
 }
 
 /// Defines methods that a valid Curve implementation must satisfy
-trait CurveTrait<Params>: std::ops::Add + std::ops::Sub + std::cmp::Eq + std::ops::Neg {
-    fn default() -> Self {
-        std::default::Default::default()
-    }
+trait CurveTrait<Params>: Add + Sub + Eq + Neg + Default {
     fn new(x: Field, y: Field) -> Self;
     fn zero() -> Self;
     fn one() -> Self;
-
-    fn add(self, x: Self) -> Self {
-        self + x
-    }
-    fn sub(self, x: Self) -> Self {
-        self - x
-    }
-    fn neg(self) -> Self {
-        std::ops::Neg::neg(self)
-    }
     fn dbl(self) -> Self;
     fn mul<let NScalarSlices: u32>(self, x: ScalarField<NScalarSlices>) -> Self;
     fn msm<let N: u32, let NScalarSlices: u32>(

--- a/src/test.nr
+++ b/src/test.nr
@@ -2,6 +2,7 @@ use crate::bjj::BabyJubJubParams;
 use crate::Curve;
 use crate::scalar_field::ScalarField;
 
+use crate::CurveTrait;
 use ec::{consts::te::baby_jubjub, tecurve::affine::Point as TEPoint};
 
 type BabyJubJub = Curve<BabyJubJubParams>;


### PR DESCRIPTION
# Description

## Problem

Noir will soon require trait methods to be in scope to be used.

In this test this line:

```noir
    let result = point.dbl().dbl().sub(point);
```

uses the `sub` method for the `CurveTrait`. Because there's also `sub` from `std::ops::Sub`, Noir now doesn't know which one to use. This PR will fix it for the upcoming release.

## Summary

In addition to using that import, I removed the default implementations of `add` and others because those are defined separately, and those default implementations will error once https://github.com/noir-lang/noir/pull/6645 is merged.

## Additional Context

For now this will produce a warning, but I guess it's fine (it will be gone when this feature is released)

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
