### PR TITLE
fix: fixed the bug in `from::<Field>`

### DIFF
--- a/Nargo.toml
+++ b/Nargo.toml
@@ -5,4 +5,3 @@ authors = [""]
 compiler_version = ">=0.37.0"
 
 [dependencies]
-ec = { tag = "v0.1.2", git = "https://github.com/noir-lang/ec" }

--- a/src/bjj.nr
+++ b/src/bjj.nr
@@ -17,3 +17,5 @@ impl TECurveParameterTrait for BabyJubJubParams {
     }
 }
 pub type BabyJubJub = Curve<BabyJubJubParams>;
+
+

--- a/src/bjj.nr
+++ b/src/bjj.nr
@@ -17,5 +17,3 @@ impl TECurveParameterTrait for BabyJubJubParams {
     }
 }
 pub type BabyJubJub = Curve<BabyJubJubParams>;
-
-

--- a/src/bjj.nr
+++ b/src/bjj.nr
@@ -11,8 +11,8 @@ impl TECurveParameterTrait for BabyJubJubParams {
     }
     fn gen() -> (Field, Field) {
         (
-            0x0bb77a6ad63e739b4eacb2e09d6277c12ab8d8010534e0b62893f3f6bb957051,
-            0x25797203f7a0b24925572e1cd16bf9edfce0051fb9e133774b3c257a872d7d8b,
+            0x023343e3445b673d38bcba38f25645adb494b1255b1162bb40f41a59f4d4b45e,
+            0x0c19139cb84c680a6e14116da06056174a0cfa121e6e5c2450f87d64fc000001,
         )
     }
 }

--- a/src/scalar_field.nr
+++ b/src/scalar_field.nr
@@ -97,21 +97,24 @@ impl<let N: u32> std::convert::From<Field> for ScalarField<N> {
 
             lo -= skew as Field;
             // Validate that the integer represented by (lo, hi) is smaller than the integer represented by (plo, phi)
-            // the lo might be negative, so we create a flag indicating if it is positive or negative
-            let is_positive: bool = lo.lt(TWO_POW_128);
+
+            // Safety: `borrow`'s value is constrained to be correct by below range constraints.
+            // Safety: we assert that the absolute value has less than 128 bits
+            let is_positive : bool = unsafe{get_borrow_flag(lo, TWO_POW_128)};
             let abs_lo = (is_positive as Field) * lo + (1 - is_positive as Field) * (PLO - lo);
+            abs_lo.assert_max_bit_size::<128>();
             // Safety: `borrow`'s value is constrained to be correct by below range constraints.
             let borrow = unsafe { get_borrow_flag(PLO, abs_lo) as Field };
-            // we only need to check the rlo has 128 bits or less if lo is positive. if negative, the lo is already less than PLO
-            let rlo = is_positive as Field * (PLO - lo + borrow * TWO_POW_128 - 1)
-                + (1 - is_positive as Field) * (-lo); // -1 because we are checking a strict <, not <=
+            // we only need to check the rlo has 128 bits or less if lo is positive. if negative, the lo is already less than PLO 
+            let rlo = is_positive as Field * (PLO - lo + borrow * TWO_POW_128 - 1) + (1 - is_positive as Field) * (-lo); // -1 because we are checking a strict <, not <=
             // is lo is positive, we need to check the hi is less than phi with the borrow flag subtracted
-            // if lo is negative, we have to check that hi * 2^128 < phi * 2^128 + abs_lo + plo
-            // to do this we first make a flag to check that abs_lo + plo is larger than 2^128 or not
-            // if they are larger, we check that hi < phi + 1 and otherwise we check that hi < phi
-            let threshold_flag = (abs_lo + PLO).lt(TWO_POW_128);
-            let rhi = is_positive as Field * (PHI - hi - borrow)
-                + (1 - is_positive as Field) * (PHI - hi - threshold_flag as Field);
+            // if lo is negative, we have to check that hi * 2^128 < phi * 2^128 + abs_lo + plo 
+            // to do this we first make a flag to check that abs_lo + plo is larger than 2^128 or not 
+            // if they are larger, we check that hi < phi + 1 and otherwise we check that hi < phi 
+            // Safety: we assert the when the flag is positive we have less than 128 bits 
+            let threshold_flag : bool = unsafe{get_borrow_flag(abs_lo + PLO, TWO_POW_128)};
+            (threshold_flag as Field * (abs_lo + PLO)).assert_max_bit_size::<128>();
+            let rhi = is_positive as Field * (PHI - hi - borrow) + (1 - is_positive as Field) * (PHI - hi + threshold_flag as Field);
             // the rlo value would have 128 bits or less if positive and more if negative as the modulus is 254 bits
             rlo.assert_max_bit_size::<128>();
             rhi.assert_max_bit_size::<128>();

--- a/src/scalar_field.nr
+++ b/src/scalar_field.nr
@@ -97,11 +97,16 @@ impl<let N: u32> std::convert::From<Field> for ScalarField<N> {
 
             lo -= skew as Field;
             // Validate that the integer represented by (lo, hi) is smaller than the integer represented by (plo, phi)
-
+            // the lo might be negative, so we create a flag indicating if it is positive or negative
+            let is_positive: bool =  lo.lt(TWO_POW_128);
+            let abs_lo = (is_positive as Field) * lo + (1 - is_positive as Field) * (PLO - lo);
             // Safety: `borrow`'s value is constrained to be correct by below range constraints.
-            let borrow = unsafe { get_borrow_flag(PLO, lo) as Field };
-            let rlo = PLO - lo + borrow * TWO_POW_128 - 1; // -1 because we are checking a strict <, not <=
-            let rhi = PHI - hi - borrow;
+            let borrow = unsafe { get_borrow_flag(PLO, abs_lo) as Field };
+            // we only need to check the rlo has 128 bits or less if lo is positive. if negative, the lo is already less than PLO 
+            let rlo = is_positive as Field * (PLO - lo + borrow * TWO_POW_128 - 1) + (1 - is_positive as Field) * (-lo); // -1 because we are checking a strict <, not <=
+            // is lo is positive, we need to check the hi is less than phi with the borrow flag subtracted
+            // if lo is negative, we have to check that the abstract value of lo has less than 128 bits, and that hi + abs_lo is less than phi
+            let rhi = is_positive as Field * (PHI - hi - borrow) + (1 - is_positive as Field) * (PHI - hi - lo);
             // the rlo value would have 128 bits or less if positive and more if negative as the modulus is 254 bits
             rlo.assert_max_bit_size::<128>();
             rhi.assert_max_bit_size::<128>();

--- a/src/scalar_field.nr
+++ b/src/scalar_field.nr
@@ -98,18 +98,20 @@ impl<let N: u32> std::convert::From<Field> for ScalarField<N> {
             lo -= skew as Field;
             // Validate that the integer represented by (lo, hi) is smaller than the integer represented by (plo, phi)
             // the lo might be negative, so we create a flag indicating if it is positive or negative
-            let is_positive: bool =  lo.lt(TWO_POW_128);
+            let is_positive: bool = lo.lt(TWO_POW_128);
             let abs_lo = (is_positive as Field) * lo + (1 - is_positive as Field) * (PLO - lo);
             // Safety: `borrow`'s value is constrained to be correct by below range constraints.
             let borrow = unsafe { get_borrow_flag(PLO, abs_lo) as Field };
-            // we only need to check the rlo has 128 bits or less if lo is positive. if negative, the lo is already less than PLO 
-            let rlo = is_positive as Field * (PLO - lo + borrow * TWO_POW_128 - 1) + (1 - is_positive as Field) * (-lo); // -1 because we are checking a strict <, not <=
+            // we only need to check the rlo has 128 bits or less if lo is positive. if negative, the lo is already less than PLO
+            let rlo = is_positive as Field * (PLO - lo + borrow * TWO_POW_128 - 1)
+                + (1 - is_positive as Field) * (-lo); // -1 because we are checking a strict <, not <=
             // is lo is positive, we need to check the hi is less than phi with the borrow flag subtracted
-            // if lo is negative, we have to check that hi * 2^128 < phi * 2^128 + abs_lo + plo 
-            // to do this we first make a flag to check that abs_lo + plo is larger than 2^128 or not 
-            // if they are larger, we check that hi < phi + 1 and otherwise we check that hi < phi 
+            // if lo is negative, we have to check that hi * 2^128 < phi * 2^128 + abs_lo + plo
+            // to do this we first make a flag to check that abs_lo + plo is larger than 2^128 or not
+            // if they are larger, we check that hi < phi + 1 and otherwise we check that hi < phi
             let threshold_flag = (abs_lo + PLO).lt(TWO_POW_128);
-            let rhi = is_positive as Field * (PHI - hi - borrow) + (1 - is_positive as Field) * (PHI - hi - threshold_flag as Field);
+            let rhi = is_positive as Field * (PHI - hi - borrow)
+                + (1 - is_positive as Field) * (PHI - hi - threshold_flag as Field);
             // the rlo value would have 128 bits or less if positive and more if negative as the modulus is 254 bits
             rlo.assert_max_bit_size::<128>();
             rhi.assert_max_bit_size::<128>();

--- a/src/scalar_field.nr
+++ b/src/scalar_field.nr
@@ -100,21 +100,23 @@ impl<let N: u32> std::convert::From<Field> for ScalarField<N> {
 
             // Safety: `borrow`'s value is constrained to be correct by below range constraints.
             // Safety: we assert that the absolute value has less than 128 bits
-            let is_positive : bool = unsafe{get_borrow_flag(lo, TWO_POW_128)};
+            let is_positive: bool = unsafe { get_borrow_flag(lo, TWO_POW_128) };
             let abs_lo = (is_positive as Field) * lo + (1 - is_positive as Field) * (PLO - lo);
             abs_lo.assert_max_bit_size::<128>();
             // Safety: `borrow`'s value is constrained to be correct by below range constraints.
             let borrow = unsafe { get_borrow_flag(PLO, abs_lo) as Field };
-            // we only need to check the rlo has 128 bits or less if lo is positive. if negative, the lo is already less than PLO 
-            let rlo = is_positive as Field * (PLO - lo + borrow * TWO_POW_128 - 1) + (1 - is_positive as Field) * (-lo); // -1 because we are checking a strict <, not <=
+            // we only need to check the rlo has 128 bits or less if lo is positive. if negative, the lo is already less than PLO
+            let rlo = is_positive as Field * (PLO - lo + borrow * TWO_POW_128 - 1)
+                + (1 - is_positive as Field) * (-lo); // -1 because we are checking a strict <, not <=
             // is lo is positive, we need to check the hi is less than phi with the borrow flag subtracted
-            // if lo is negative, we have to check that hi * 2^128 < phi * 2^128 + abs_lo + plo 
-            // to do this we first make a flag to check that abs_lo + plo is larger than 2^128 or not 
-            // if they are larger, we check that hi < phi + 1 and otherwise we check that hi < phi 
-            // Safety: we assert the when the flag is positive we have less than 128 bits 
-            let threshold_flag : bool = unsafe{get_borrow_flag(abs_lo + PLO, TWO_POW_128)};
+            // if lo is negative, we have to check that hi * 2^128 < phi * 2^128 + abs_lo + plo
+            // to do this we first make a flag to check that abs_lo + plo is larger than 2^128 or not
+            // if they are larger, we check that hi < phi + 1 and otherwise we check that hi < phi
+            // Safety: we assert the when the flag is positive we have less than 128 bits
+            let threshold_flag: bool = unsafe { get_borrow_flag(abs_lo + PLO, TWO_POW_128) };
             (threshold_flag as Field * (abs_lo + PLO)).assert_max_bit_size::<128>();
-            let rhi = is_positive as Field * (PHI - hi - borrow) + (1 - is_positive as Field) * (PHI - hi + threshold_flag as Field);
+            let rhi = is_positive as Field * (PHI - hi - borrow)
+                + (1 - is_positive as Field) * (PHI - hi + threshold_flag as Field);
             // the rlo value would have 128 bits or less if positive and more if negative as the modulus is 254 bits
             rlo.assert_max_bit_size::<128>();
             rhi.assert_max_bit_size::<128>();

--- a/src/scalar_field.nr
+++ b/src/scalar_field.nr
@@ -85,27 +85,26 @@ impl<let N: u32> std::convert::From<Field> for ScalarField<N> {
             assert(acc - skew as Field == x);
         } else {
             // TODO: if num bits = 64, validate in sum of the bits is smaller than the Field modulus
-            let mut lo: Field = 0; 
+            let mut lo: Field = 0;
             let mut hi: Field = 0;
-            
+
             for i in 0..32 {
                 lo *= 16;
                 lo += (slices[32 + i] as Field) * 2 - 15;
                 hi *= 16;
                 hi += (slices[i] as Field) * 2 - 15;
             }
-            
+
             lo -= skew as Field;
             // Validate that the integer represented by (lo, hi) is smaller than the integer represented by (plo, phi)
-            
+
             // Safety: `borrow`'s value is constrained to be correct by below range constraints.
-            let borrow = unsafe{get_borrow_flag(PLO, lo) as Field};
-            let rlo = PLO - lo + borrow * TWO_POW_128 -1;  // -1 because we are checking a strict <, not <=
+            let borrow = unsafe { get_borrow_flag(PLO, lo) as Field };
+            let rlo = PLO - lo + borrow * TWO_POW_128 - 1; // -1 because we are checking a strict <, not <=
             let rhi = PHI - hi - borrow;
             // the rlo value would have 128 bits or less if positive and more if negative as the modulus is 254 bits
             rlo.assert_max_bit_size::<128>();
             rhi.assert_max_bit_size::<128>();
-            
         }
         for i in 0..N {
             (result.base4_slices[i] as Field).assert_max_bit_size::<4>();

--- a/src/scalar_field.nr
+++ b/src/scalar_field.nr
@@ -105,8 +105,11 @@ impl<let N: u32> std::convert::From<Field> for ScalarField<N> {
             // we only need to check the rlo has 128 bits or less if lo is positive. if negative, the lo is already less than PLO 
             let rlo = is_positive as Field * (PLO - lo + borrow * TWO_POW_128 - 1) + (1 - is_positive as Field) * (-lo); // -1 because we are checking a strict <, not <=
             // is lo is positive, we need to check the hi is less than phi with the borrow flag subtracted
-            // if lo is negative, we have to check that the abstract value of lo has less than 128 bits, and that hi + abs_lo is less than phi
-            let rhi = is_positive as Field * (PHI - hi - borrow) + (1 - is_positive as Field) * (PHI - hi - lo);
+            // if lo is negative, we have to check that hi * 2^128 < phi * 2^128 + abs_lo + plo 
+            // to do this we first make a flag to check that abs_lo + plo is larger than 2^128 or not 
+            // if they are larger, we check that hi < phi + 1 and otherwise we check that hi < phi 
+            let threshold_flag = (abs_lo + PLO).lt(TWO_POW_128);
+            let rhi = is_positive as Field * (PHI - hi - borrow) + (1 - is_positive as Field) * (PHI - hi - threshold_flag as Field);
             // the rlo value would have 128 bits or less if positive and more if negative as the modulus is 254 bits
             rlo.assert_max_bit_size::<128>();
             rhi.assert_max_bit_size::<128>();

--- a/src/scalar_field.nr
+++ b/src/scalar_field.nr
@@ -1,3 +1,5 @@
+use std::static_assert;
+
 /// ScalarField represents a scalar multiplier as a sequence of 4-bit slices
 ///
 /// There is nuance to ScalarField, because twisted edwards curves generally have prime group orders that easily fit into a Field
@@ -10,6 +12,10 @@
 ///
 /// N.B. ScalarField bit values are not constrained to be smaller than the TE curve group order.
 /// ScalarField is used when performing scalar multiplications, where all operations wrap modulo the curve order
+pub global TWO_POW_128: Field = 0x100000000000000000000000000000000;
+pub global PLO: Field = 0x2833e84879b9709143e1f593f0000001;
+pub global PHI: Field = 0x30644e72e131a029b85045b68181585d;
+
 pub struct ScalarField<let N: u32> {
     pub(crate) base4_slices: [u8; N],
     pub(crate) skew: bool,
@@ -33,10 +39,10 @@ unconstrained fn get_wnaf_slices<let N: u32>(x: Field) -> ([u8; N], bool) {
     (result, skew)
 }
 
-unconstrained fn from_wnaf_slices(x: [u8; 64], skew: bool) -> Field {
+unconstrained fn from_wnaf_slices<let N: u32>(x: [u8; N], skew: bool) -> Field {
     let mut result: Field = 0;
 
-    for i in 0..64 {
+    for i in 0..N {
         result *= 16;
         result += (x[i] as Field) * 2 - 15;
     }
@@ -48,28 +54,10 @@ unconstrained fn from_wnaf_slices(x: [u8; 64], skew: bool) -> Field {
 fn test_wnaf() {
     unsafe {
         let result: Field = 0x123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0;
-        let (t0, t1) = get_wnaf_slices(result);
+        let (t0, t1) = get_wnaf_slices::<64>(result);
         let expected = from_wnaf_slices(t0, t1);
         assert(result == expected);
     }
-}
-
-comptime fn get_modulus_slices() -> (Field, Field) {
-    let bytes = std::field::modulus_be_bytes();
-    let num_bytes = std::field::modulus_num_bits() / 8;
-    let mut lo: Field = 0;
-    let mut hi: Field = 0;
-    for i in 0..(num_bytes / 2) {
-        hi *= 256;
-        hi += bytes[i] as Field;
-        lo *= 256;
-        lo += bytes[i + (num_bytes / 2)] as Field;
-    }
-    if (num_bytes & 1 == 1) {
-        lo *= 256;
-        lo += bytes[num_bytes - 1] as Field;
-    }
-    (lo, hi)
 }
 
 unconstrained fn get_borrow_flag(lhs_lo: Field, rhs_lo: Field) -> bool {
@@ -82,6 +70,8 @@ impl<let N: u32> std::convert::From<Field> for ScalarField<N> {
     /// if N >= 64 we perform extra checks to ensure the slice decomposition represents the same integral value as the input
     /// (e.g. sum of slices != x + modulus)
     fn from(x: Field) -> Self {
+        // the field elements have 254 bits max, so we do not need to support N > 64
+        static_assert(N <= 64, "N must be at most 64");
         let mut result: Self = ScalarField { base4_slices: [0; N], skew: false };
         let (slices, skew): ([u8; N], bool) = unsafe { get_wnaf_slices(x) };
         result.base4_slices = slices;
@@ -95,33 +85,27 @@ impl<let N: u32> std::convert::From<Field> for ScalarField<N> {
             assert(acc - skew as Field == x);
         } else {
             // TODO: if num bits = 64, validate in sum of the bits is smaller than the Field modulus
-            let mut lo: Field = slices[(N / 2)] as Field;
-            let mut hi: Field = slices[0] as Field;
-            let mut borrow_shift = 1;
-            for i in 1..(N / 2) {
-                borrow_shift *= 16;
+            let mut lo: Field = 0; 
+            let mut hi: Field = 0;
+            
+            for i in 0..32 {
                 lo *= 16;
-                lo += (slices[(N / 2) + i] as Field) * 2 - 15;
+                lo += (slices[32 + i] as Field) * 2 - 15;
                 hi *= 16;
                 hi += (slices[i] as Field) * 2 - 15;
             }
-            if ((N & 1) == 1) {
-                borrow_shift *= 16;
-                lo *= 16;
-                lo += (slices[N - 1] as Field) * 2 - 15;
-            }
+            
             lo -= skew as Field;
             // Validate that the integer represented by (lo, hi) is smaller than the integer represented by (plo, phi)
-            let (plo, phi) = comptime { get_modulus_slices() };
-            unsafe {
-                // Safety: `borrow`'s value is constrained to be correct by below range constraints.
-                let borrow = get_borrow_flag(plo, lo) as Field;
-
-                let rlo = plo - lo + borrow * borrow_shift - 1; // -1 because we are checking a strict <, not <=
-                let rhi = phi - hi - borrow;
-                rlo.assert_max_bit_size::<(N / 2 + N % 2) * 4>();
-                rhi.assert_max_bit_size::<N / 2 * 4>();
-            }
+            
+            // Safety: `borrow`'s value is constrained to be correct by below range constraints.
+            let borrow = unsafe{get_borrow_flag(PLO, lo) as Field};
+            let rlo = PLO - lo + borrow * TWO_POW_128 -1;  // -1 because we are checking a strict <, not <=
+            let rhi = PHI - hi - borrow;
+            // the rlo value would have 128 bits or less if positive and more if negative as the modulus is 254 bits
+            rlo.assert_max_bit_size::<128>();
+            rhi.assert_max_bit_size::<128>();
+            
         }
         for i in 0..N {
             (result.base4_slices[i] as Field).assert_max_bit_size::<4>();

--- a/src/test.nr
+++ b/src/test.nr
@@ -1,9 +1,9 @@
 use crate::bjj::BabyJubJubParams;
 use crate::Curve;
-use crate::scalar_field::ScalarField;
-
 use crate::CurveTrait;
-use ec::{consts::te::baby_jubjub, tecurve::affine::Point as TEPoint};
+use crate::scalar_field::ScalarField;
+use dep::ec::consts::te::baby_jubjub;
+use ec::tecurve::affine::Point as TEPoint;
 
 type BabyJubJub = Curve<BabyJubJubParams>;
 
@@ -14,7 +14,7 @@ fn test_sub() {
     let point: Curve<BabyJubJubParams> = Curve { x: bjj_point.x, y: bjj_point.y };
 
     let expected = point + (point + (point));
-    let result = point.dbl().dbl().sub(point);
+    let result = point.dbl().dbl() - point;
     assert(result.x == expected.x);
     assert(result.y == expected.y);
 }

--- a/src/test.nr
+++ b/src/test.nr
@@ -1,18 +1,18 @@
-use crate::bjj::BabyJubJubParams;
+use crate::bjj::{BabyJubJubParams, BabyJubJub};
 use crate::Curve;
 use crate::CurveTrait;
 use crate::scalar_field::ScalarField;
 use dep::ec::consts::te::baby_jubjub;
 use ec::tecurve::affine::Point as TEPoint;
 
-type BabyJubJub = Curve<BabyJubJubParams>;
+global BASE8: [Field; 2] = [
+    5299619240641551281634865583518297030282874472190772894086521144482721001553,
+    16950150798460657717958625567821834550301663161624707787222815936182638968203,
+];
 
 #[test]
 fn test_sub() {
-    let bjj = baby_jubjub();
-    let bjj_point = bjj.base8;
-    let point: Curve<BabyJubJubParams> = Curve { x: bjj_point.x, y: bjj_point.y };
-
+    let point: Curve<BabyJubJubParams> = Curve { x: BASE8[0], y: BASE8[1] };
     let expected = point + (point + (point));
     let result = point.dbl().dbl() - point;
     assert(result.x == expected.x);
@@ -20,17 +20,36 @@ fn test_sub() {
 }
 
 #[test]
-fn test_mul() {
-    let scalar = 13439285682734681346581734618;
-    let bjj = baby_jubjub();
-    let bjj_point = bjj.base8;
-
-    let expected = bjj.curve.mul(scalar, bjj_point);
+fn test_scalar_mul_1() {
+    let scalar = 9;
+    let bjj_point = BabyJubJub::new(BASE8[0], BASE8[1]);
     let scalar_f: ScalarField<63> = ScalarField::from(scalar);
-    let point: BabyJubJub = Curve { x: bjj_point.x, y: bjj_point.y };
+    let expected = bjj_point.mul(scalar_f);
+    let mut result = bjj_point.dbl().dbl().dbl(); 
+    result = result+ bjj_point;
+    assert(result.x == expected.x);
+    assert(result.y == expected.y);
+}
+
+#[test]
+fn test_scalar_mul_2() {
+    let scalar = 125008707422548553008458566692055115405265404091165231253731979; 
+    let point: BabyJubJub = BabyJubJub{x: 0x0bb77a6ad63e739b4eacb2e09d6277c12ab8d8010534e0b62893f3f6bb957051,
+            y: 0x25797203f7a0b24925572e1cd16bf9edfce0051fb9e133774b3c257a872d7d8b};
+    let scalar_f: ScalarField<63> = ScalarField::from(scalar);
     let result = point.mul(scalar_f);
-    let scalar_converted: Field = ScalarField::into(scalar_f);
-    assert(scalar_converted == scalar);
+    let expected : BabyJubJub = BabyJubJub{x: 617161874567552582384121722828904445762099298246151845490568021290206689792, y: 13034886054222108846214594281471929075849418819835081605284620402790201340104 };
+    assert(result.x == expected.x);
+    assert(result.y == expected.y);
+}
+
+#[test]
+fn test_scalar_mul_3() {
+    let scalar = 54151461856964260907680256125457277518023881635046757770759266; 
+    let point: BabyJubJub = BabyJubJub{x: BASE8[0], y: BASE8[1]};
+    let scalar_f: ScalarField<63> = ScalarField::from(scalar);
+    let result = point.mul(scalar_f);
+    let expected : BabyJubJub = BabyJubJub{x: 19208535741451908456059246935738795913108647784428496829884866473148752123890, y: 11995935797001296221514672688383396330912779758746145432661060411923774860388 };
     assert(result.x == expected.x);
     assert(result.y == expected.y);
 }
@@ -43,7 +62,7 @@ fn test_msm() {
 
     let point: BabyJubJub = Curve { x: bjj_point.x, y: bjj_point.y };
     let mut scalar_values: [Field; 1] = [0; 1];
-    let mut points: [BabyJubJub; 1] = [Curve { x: 0, y: 0 }; 1];
+    let mut points: [Curve<BabyJubJubParams>; 1] = [Curve { x: 0, y: 0 }; 1];
     let mut scalars: [ScalarField<63>; 1] = [ScalarField::new(); 1];
     let mut bjj_points: [TEPoint; 1] = [TEPoint::new(0, 0); 1];
 

--- a/src/test.nr
+++ b/src/test.nr
@@ -1,7 +1,7 @@
 use crate::bjj::{BabyJubJub, BabyJubJubParams};
 use crate::Curve;
 use crate::CurveTrait;
-use crate::scalar_field::ScalarField;
+use crate::scalar_field::{PHI, PLO, ScalarField, TWO_POW_128};
 
 global BASE8: [Field; 2] = [
     5299619240641551281634865583518297030282874472190772894086521144482721001553,
@@ -146,4 +146,18 @@ fn test_msm() {
 
     assert(result.x == expected.x);
     assert(result.y == expected.y);
+}
+
+#[test]
+fn test_scalar_field_regression() {
+    let x: Field = 0x1ef95a3b5635862db98787c295876d096121b81e2523c5bfa35986b411872655;
+    let scalar_field: ScalarField<64> = ScalarField::<64>::from(x);
+    assert(scalar_field.into() == x);
+}
+
+#[test]
+fn test_globals() {
+    PLO.assert_max_bit_size::<128>();
+    PHI.assert_max_bit_size::<128>();
+    assert(PLO + PHI * TWO_POW_128 == 0);
 }

--- a/src/test.nr
+++ b/src/test.nr
@@ -147,3 +147,20 @@ fn test_msm() {
     assert(result.x == expected.x);
     assert(result.y == expected.y);
 }
+
+#[test]
+fn test_scalar_field_2() {
+    let scalars =
+        [ScalarField::<63>::from(1), ScalarField::<63>::from(2), ScalarField::<63>::from(3)];
+    let scalar = ScalarField::<63>::from(6);
+    let point = BabyJubJub { x: BASE8[0], y: BASE8[1] };
+    let points = [
+        BabyJubJub { x: BASE8[0], y: BASE8[1] },
+        BabyJubJub { x: BASE8[0], y: BASE8[1] },
+        BabyJubJub { x: BASE8[0], y: BASE8[1] },
+    ];
+    let result = Curve::msm(points, scalars);
+    let expected = point.mul(scalar);
+    assert(result.x == expected.x);
+    assert(result.y == expected.y);
+}

--- a/src/test.nr
+++ b/src/test.nr
@@ -149,7 +149,7 @@ fn test_msm() {
 }
 
 #[test]
-fn test_scalar_field_2() {
+fn test_msm_2() {
     let scalars =
         [ScalarField::<63>::from(1), ScalarField::<63>::from(2), ScalarField::<63>::from(3)];
     let scalar = ScalarField::<63>::from(6);

--- a/src/test.nr
+++ b/src/test.nr
@@ -151,14 +151,11 @@ fn test_msm() {
 
 #[test]
 fn test_scalar_field_regression() {
-
     let x: Field = 0x216b776d574b1fc3b5a87247c240b0aee5f876735930bc682e5f0bd21f52936e;
     println(f"x: {x}");
-    
+
     let scalar_field: ScalarField<64> = ScalarField::<64>::from(x);
     assert(scalar_field.into() == x);
-   
-
 }
 
 #[test]

--- a/src/test.nr
+++ b/src/test.nr
@@ -155,7 +155,7 @@ fn test_scalar_field_regression() {
     println(f"x: {x}");
 
     let scalar_field: ScalarField<64> = ScalarField::<64>::from(x);
-    assert(scalar_field.into() == x);
+    assert(ScalarField::into(scalar_field) == x);
 }
 
 #[test]

--- a/src/test.nr
+++ b/src/test.nr
@@ -1,9 +1,7 @@
-use crate::bjj::{BabyJubJubParams, BabyJubJub};
+use crate::bjj::{BabyJubJub, BabyJubJubParams};
 use crate::Curve;
 use crate::CurveTrait;
 use crate::scalar_field::ScalarField;
-use dep::ec::consts::te::baby_jubjub;
-use ec::tecurve::affine::Point as TEPoint;
 
 global BASE8: [Field; 2] = [
     5299619240641551281634865583518297030282874472190772894086521144482721001553,
@@ -25,71 +23,126 @@ fn test_scalar_mul_1() {
     let bjj_point = BabyJubJub::new(BASE8[0], BASE8[1]);
     let scalar_f: ScalarField<63> = ScalarField::from(scalar);
     let expected = bjj_point.mul(scalar_f);
-    let mut result = bjj_point.dbl().dbl().dbl(); 
-    result = result+ bjj_point;
+    let mut result = bjj_point.dbl().dbl().dbl();
+    result = result + bjj_point;
     assert(result.x == expected.x);
     assert(result.y == expected.y);
 }
 
 #[test]
 fn test_scalar_mul_2() {
-    let scalar = 125008707422548553008458566692055115405265404091165231253731979; 
-    let point: BabyJubJub = BabyJubJub{x: 0x0bb77a6ad63e739b4eacb2e09d6277c12ab8d8010534e0b62893f3f6bb957051,
-            y: 0x25797203f7a0b24925572e1cd16bf9edfce0051fb9e133774b3c257a872d7d8b};
+    let scalar = 125008707422548553008458566692055115405265404091165231253731979;
+    let point: BabyJubJub = BabyJubJub {
+        x: 0x0bb77a6ad63e739b4eacb2e09d6277c12ab8d8010534e0b62893f3f6bb957051,
+        y: 0x25797203f7a0b24925572e1cd16bf9edfce0051fb9e133774b3c257a872d7d8b,
+    };
     let scalar_f: ScalarField<63> = ScalarField::from(scalar);
     let result = point.mul(scalar_f);
-    let expected : BabyJubJub = BabyJubJub{x: 617161874567552582384121722828904445762099298246151845490568021290206689792, y: 13034886054222108846214594281471929075849418819835081605284620402790201340104 };
+    let expected: BabyJubJub = BabyJubJub {
+        x: 617161874567552582384121722828904445762099298246151845490568021290206689792,
+        y: 13034886054222108846214594281471929075849418819835081605284620402790201340104,
+    };
     assert(result.x == expected.x);
     assert(result.y == expected.y);
 }
 
 #[test]
 fn test_scalar_mul_3() {
-    let scalar = 54151461856964260907680256125457277518023881635046757770759266; 
-    let point: BabyJubJub = BabyJubJub{x: BASE8[0], y: BASE8[1]};
+    let scalar = 54151461856964260907680256125457277518023881635046757770759266;
+    let point: BabyJubJub = BabyJubJub { x: BASE8[0], y: BASE8[1] };
     let scalar_f: ScalarField<63> = ScalarField::from(scalar);
     let result = point.mul(scalar_f);
-    let expected : BabyJubJub = BabyJubJub{x: 19208535741451908456059246935738795913108647784428496829884866473148752123890, y: 11995935797001296221514672688383396330912779758746145432661060411923774860388 };
+    let expected: BabyJubJub = BabyJubJub {
+        x: 19208535741451908456059246935738795913108647784428496829884866473148752123890,
+        y: 11995935797001296221514672688383396330912779758746145432661060411923774860388,
+    };
     assert(result.x == expected.x);
     assert(result.y == expected.y);
 }
 
 #[test]
 fn test_msm() {
-    let scalar = 13439285682734681346581734618;
-    let bjj = baby_jubjub();
-    let bjj_point = bjj.base8;
+    let bjj_point = BabyJubJub {
+        x: 0x0bb77a6ad63e739b4eacb2e09d6277c12ab8d8010534e0b62893f3f6bb957051,
+        y: 0x25797203f7a0b24925572e1cd16bf9edfce0051fb9e133774b3c257a872d7d8b,
+    };
 
-    let point: BabyJubJub = Curve { x: bjj_point.x, y: bjj_point.y };
-    let mut scalar_values: [Field; 1] = [0; 1];
-    let mut points: [Curve<BabyJubJubParams>; 1] = [Curve { x: 0, y: 0 }; 1];
-    let mut scalars: [ScalarField<63>; 1] = [ScalarField::new(); 1];
-    let mut bjj_points: [TEPoint; 1] = [TEPoint::new(0, 0); 1];
+    let scalars = [
+        ScalarField::<63>::from(1),
+        ScalarField::<63>::from(
+            22096485197410035909796157153320654984986529955857497602977111,
+        ),
+        ScalarField::<63>::from(
+            65246305321293276263364651658295321649030097759571141639656096,
+        ),
+        ScalarField::<63>::from(
+            10783877200430517958910274429249773390381127732782098389956753,
+        ),
+        ScalarField::<63>::from(
+            85115736955169157032026426022325039306882570918771222968894742,
+        ),
+        ScalarField::<63>::from(
+            8007661759673469897619789883995943075483797120112799675116988,
+        ),
+        ScalarField::<63>::from(
+            120632748994973016066965702250208710570048996425404505467379186,
+        ),
+        ScalarField::<63>::from(
+            7880449440789589435266457223958696289620324225124952334738121,
+        ),
+        ScalarField::<63>::from(
+            86393120011600029661131030778522549251804186678072815524194808,
+        ),
+        ScalarField::<63>::from(
+            87733764451921476238239626348847201783164441449836684513847657,
+        ),
+    ];
 
-    points[0] = point;
-    scalar_values[0] = scalar;
-    scalars[0] = ScalarField::from(scalar_values[0]);
-    bjj_points[0] = TEPoint::new(points[0].x, points[0].y);
-
-    for i in 1..1 {
-        points[i] = points[i - 1].dbl();
-        scalar_values[i] = scalar_values[i - 1] + scalar;
-    }
-
-    for i in 0..1 {
-        scalars[i] = ScalarField::from(scalar_values[i]);
-        bjj_points[i] = TEPoint::new(points[i].x, points[i].y);
-        let scalar_expected = scalar_values[i];
-        let scalar_result: Field = ScalarField::into(scalars[i]);
-        assert(scalar_result == scalar_expected);
-
-        let result_point = points[i].mul(scalars[i]);
-        let expected_point = bjj.curve.mul(scalar_values[i], bjj_points[i]);
-        assert(result_point.x == expected_point.x);
-        assert(result_point.y == expected_point.y);
-    }
-    let expected = bjj.curve.msm(scalar_values, bjj_points);
+    let points = [
+        bjj_point,
+        BabyJubJub {
+            x: 6908307910410799727742014631870645132468849638438785192023894233964747648246,
+            y: 1117247569715206928008211232281782362917630199461454595461800473556215015531,
+        },
+        BabyJubJub {
+            x: 20961750243890720535629167040809652791859594413096044973136607904650832264730,
+            y: 3667872899218539236578732091671023586522699998168411741204352569314950923203,
+        },
+        BabyJubJub {
+            x: 9242845010005317730554303618656955152057106587627235401784820451786543272328,
+            y: 8361223956059552338001832638570050886817197127330309519914796154028334872651,
+        },
+        BabyJubJub {
+            x: 14695455247551978427572444624408674826222153759343114431423847408522503291511,
+            y: 17083718747713825481233561791146947590762250218126109450127826273602275602945,
+        },
+        BabyJubJub {
+            x: 12651252941938248665893806292608903013146642645301298232801488188791583313284,
+            y: 2696575039526434571211651150692815966656551007520222995710428115207480112887,
+        },
+        BabyJubJub {
+            x: 7851198486663817094882669094016375866490899059694847247154885216608493354280,
+            y: 13029415159272931747874822423922297641162291322751711599799454751602691242083,
+        },
+        BabyJubJub {
+            x: 17157209920272988621763172574968463086712340171272077002499355712694599831919,
+            y: 21429257232797467406552146211729253324737611878355163665519157983173871945271,
+        },
+        BabyJubJub {
+            x: 10126291830257109041882984305316110558514650221195031244344949855101922260578,
+            y: 7356838874813998377349355063760749355414350391995970274536579749579154432749,
+        },
+        BabyJubJub {
+            x: 16373445850576846598377550621753030487980229051510483964934158889959117451333,
+            y: 571457541426255272935595262428513985863469854864356275416794825997199661466,
+        },
+    ];
     let result = Curve::msm(points, scalars);
+
+    let expected = BabyJubJub {
+        x: 0x2d4030b35ef0c22ec905ac20f5292c4484a236f70171b41dd4384081c6a53617,
+        y: 0x19a88b791ce81b6181d10e87c81cf962757129dd4da39b13529e32ece9015e05,
+    };
 
     assert(result.x == expected.x);
     assert(result.y == expected.y);

--- a/src/test.nr
+++ b/src/test.nr
@@ -152,8 +152,6 @@ fn test_msm() {
 #[test]
 fn test_scalar_field_regression() {
     let x: Field = 0x216b776d574b1fc3b5a87247c240b0aee5f876735930bc682e5f0bd21f52936e;
-    println(f"x: {x}");
-
     let scalar_field: ScalarField<64> = ScalarField::<64>::from(x);
     assert(ScalarField::into(scalar_field) == x);
 }

--- a/src/test.nr
+++ b/src/test.nr
@@ -1,7 +1,7 @@
 use crate::bjj::{BabyJubJub, BabyJubJubParams};
 use crate::Curve;
 use crate::CurveTrait;
-use crate::scalar_field::{ScalarField, PLO, PHI, TWO_POW_128};
+use crate::scalar_field::{PHI, PLO, ScalarField, TWO_POW_128};
 
 global BASE8: [Field; 2] = [
     5299619240641551281634865583518297030282874472190772894086521144482721001553,
@@ -164,7 +164,6 @@ fn test_msm_2() {
     assert(result.x == expected.x);
     assert(result.y == expected.y);
 }
-
 
 #[test]
 fn test_scalar_field_regression() {

--- a/src/test.nr
+++ b/src/test.nr
@@ -1,7 +1,7 @@
 use crate::bjj::{BabyJubJub, BabyJubJubParams};
 use crate::Curve;
 use crate::CurveTrait;
-use crate::scalar_field::ScalarField;
+use crate::scalar_field::{ScalarField, PLO, PHI, TWO_POW_128};
 
 global BASE8: [Field; 2] = [
     5299619240641551281634865583518297030282874472190772894086521144482721001553,
@@ -163,4 +163,17 @@ fn test_msm_2() {
     let expected = point.mul(scalar);
     assert(result.x == expected.x);
     assert(result.y == expected.y);
+}
+
+
+#[test]
+fn test_scalar_field_regression() {
+    let x: Field = 0x1ef95a3b5635862db98787c295876d096121b81e2523c5bfa35986b411872655;
+    let scalar_field: ScalarField<64> = ScalarField::<64>::from(x);
+    assert(scalar_field.into() == x);
+}
+
+#[test]
+fn test_globals() {
+    assert(PLO + PHI * TWO_POW_128 == 0);
 }

--- a/src/test.nr
+++ b/src/test.nr
@@ -1,7 +1,7 @@
 use crate::bjj::{BabyJubJub, BabyJubJubParams};
 use crate::Curve;
 use crate::CurveTrait;
-use crate::scalar_field::{PHI, PLO, ScalarField, TWO_POW_128};
+use crate::scalar_field::ScalarField;
 
 global BASE8: [Field; 2] = [
     5299619240641551281634865583518297030282874472190772894086521144482721001553,
@@ -146,33 +146,4 @@ fn test_msm() {
 
     assert(result.x == expected.x);
     assert(result.y == expected.y);
-}
-
-#[test]
-fn test_msm_2() {
-    let scalars =
-        [ScalarField::<63>::from(1), ScalarField::<63>::from(2), ScalarField::<63>::from(3)];
-    let scalar = ScalarField::<63>::from(6);
-    let point = BabyJubJub { x: BASE8[0], y: BASE8[1] };
-    let points = [
-        BabyJubJub { x: BASE8[0], y: BASE8[1] },
-        BabyJubJub { x: BASE8[0], y: BASE8[1] },
-        BabyJubJub { x: BASE8[0], y: BASE8[1] },
-    ];
-    let result = Curve::msm(points, scalars);
-    let expected = point.mul(scalar);
-    assert(result.x == expected.x);
-    assert(result.y == expected.y);
-}
-
-#[test]
-fn test_scalar_field_regression() {
-    let x: Field = 0x1ef95a3b5635862db98787c295876d096121b81e2523c5bfa35986b411872655;
-    let scalar_field: ScalarField<64> = ScalarField::<64>::from(x);
-    assert(scalar_field.into() == x);
-}
-
-#[test]
-fn test_globals() {
-    assert(PLO + PHI * TWO_POW_128 == 0);
 }

--- a/src/test.nr
+++ b/src/test.nr
@@ -3,6 +3,7 @@ use crate::Curve;
 use crate::CurveTrait;
 use crate::scalar_field::{PHI, PLO, ScalarField, TWO_POW_128};
 
+pub global TWO_POW_252: Field = 0x1000000000000000000000000000000000000000000000000000000000000000;
 global BASE8: [Field; 2] = [
     5299619240641551281634865583518297030282874472190772894086521144482721001553,
     16950150798460657717958625567821834550301663161624707787222815936182638968203,
@@ -150,9 +151,14 @@ fn test_msm() {
 
 #[test]
 fn test_scalar_field_regression() {
-    let x: Field = 0x1ef95a3b5635862db98787c295876d096121b81e2523c5bfa35986b411872655;
+
+    let x: Field = 0x216b776d574b1fc3b5a87247c240b0aee5f876735930bc682e5f0bd21f52936e;
+    println(f"x: {x}");
+    
     let scalar_field: ScalarField<64> = ScalarField::<64>::from(x);
     assert(scalar_field.into() == x);
+   
+
 }
 
 #[test]


### PR DESCRIPTION
# Description
There was an issue in the logic that was not caught by any of the tests. 
I stumbled upon this while changing the `eddsa` to use `noir_edwards` instead of `ec`. 
Meanwhile, I did some small refactoring, removed some comptime functions and replaced them with globals. 
I also opted to have a static assert for the numeric generic `N`. as we do not need arrays of length more than 
`64` when converting from `Field`. 

## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
