### PR TITLE
fix: always use u32 to index arrays

### DIFF
--- a/src/lib.nr
+++ b/src/lib.nr
@@ -221,7 +221,7 @@ where
         let (table_x, table_y): ([Field; 16], [Field; 16]) = self.compute_straus_point_table(a, d);
 
         // Initialize the accumulator with the point that maps to the first (most significant) scalar slice
-        let idx = scalar.base4_slices[0];
+        let idx = scalar.base4_slices[0] as u32;
         let mut accumulator: Self = Curve { x: table_x[idx], y: table_y[idx] };
 
         // Execute a double-and-add subroutine
@@ -234,7 +234,7 @@ where
             accumulator = accumulator.dbl_internal(a, d);
             accumulator = accumulator.dbl_internal(a, d);
             accumulator = accumulator.dbl_internal(a, d);
-            let idx: u8 = scalar.base4_slices[i];
+            let idx = scalar.base4_slices[i] as u32;
             let x = table_x[idx];
             let y = table_y[idx];
             accumulator = accumulator.add_internal(Curve { x, y }, a, d);
@@ -279,10 +279,10 @@ where
             point_tables[j] = points[j].compute_straus_point_table(a, d);
         }
 
-        let idx = scalars[0].base4_slices[0];
+        let idx = scalars[0].base4_slices[0] as u32;
         let mut accumulator: Self = Curve { x: point_tables[0].0[idx], y: point_tables[0].1[idx] };
         for j in 1..N {
-            let idx = scalars[j].base4_slices[0];
+            let idx = scalars[j].base4_slices[0] as u32;
             let P = Curve { x: point_tables[j].0[idx], y: point_tables[j].1[idx] };
             accumulator = accumulator.add_internal(P, a, d);
         }
@@ -292,7 +292,7 @@ where
             accumulator = accumulator.dbl_internal(a, d);
             accumulator = accumulator.dbl_internal(a, d);
             for j in 0..N {
-                let idx: u8 = scalars[j].base4_slices[i];
+                let idx = scalars[j].base4_slices[i] as u32;
                 let x = point_tables[j].0[idx];
                 let y = point_tables[j].1[idx];
                 accumulator = accumulator.add_internal(Curve { x, y }, a, d);

--- a/src/scalar_field.nr
+++ b/src/scalar_field.nr
@@ -141,7 +141,7 @@ impl<let N: u32> ScalarField<N> {
     pub fn new() -> Self {
         Self { base4_slices: [0; N], skew: false }
     }
-    fn get(self, idx: u64) -> u8 {
+    fn get(self, idx: u32) -> u8 {
         self.base4_slices[idx]
     }
 }


### PR DESCRIPTION
# Description

## Problem

Towards https://github.com/noir-lang/noir/pull/7908

## Summary

In this case `base4_slices` is a `u8` array, so `as u32` would just do a cast, never a truncation that could "fail".

## Additional Context



# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
