### PR TITLE
fix: let the bjj module be public

### DIFF
--- a/src/lib.nr
+++ b/src/lib.nr
@@ -1,6 +1,6 @@
 mod scalar_field;
 mod test;
-mod bjj;
+pub mod bjj;
 
 pub use crate::scalar_field::ScalarField;
 use std::ops::{Add, Neg, Sub};


### PR DESCRIPTION
# Description

## Problem

There's otherwise no way to refer to `BabyJubJubParams` or `BabyJubJub`.

## Summary

Right now they can be referenced without an error because of a bug in Noir. Once https://github.com/noir-lang/noir/pull/9295 that will error. 

## Additional Context



# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
