### PR TITLE
fix(curve): constrain unused `lambda` Brillig return in dbl_internal

### DIFF
--- a/src/lib.nr
+++ b/src/lib.nr
@@ -362,6 +362,7 @@ impl<Params> Curve<Params> {
         // i.e. x_3 = 2 * x_1 * y_1 / (y_1^2 + a * x_1^2)
         let t2 = x3 * t1 - t4;
         assert(t2 == t4);
+        assert(lambda == t4 * t4);
         Self { x: x3, y: y3 }
     }
 


### PR DESCRIPTION
Constrain the previously-discarded `lambda` Brillig return in `Curve::dbl_internal`. This is a soundness fix that also unbreaks compilation on newer Noir toolchains.